### PR TITLE
add support for run-once

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,11 +73,7 @@ func main() {
 			log.Println(err)
 		}
 
-		if dryRun {
-			return
-		} else {
-			time.Sleep(sleepDur)
-		}
+		time.Sleep(sleepDur)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,9 @@ import (
 
 func main() {
 	var dryRun bool
-	flag.BoolVar(&dryRun, "dry-run", false, "If true, will only print planned actions")
+	var runOnce bool
+	flag.BoolVar(&dryRun, "dry-run", true, "If true, will only print planned actions")
+	flag.BoolVar(&dryRun, "run-once", true, "If true, will exit after single execution")
 	flag.Parse()
 
 	// define vars to look for and any defaults
@@ -73,7 +75,11 @@ func main() {
 			log.Println(err)
 		}
 
-		time.Sleep(sleepDur)
+		if runOnce {
+			return
+		} else {
+			time.Sleep(sleepDur)
+		}
 	}
 }
 

--- a/openshift/producer.yaml
+++ b/openshift/producer.yaml
@@ -36,7 +36,7 @@ objects:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: git-partition-sync-producer
-          args: ["-dry-run=${DRY_RUN}"]
+          args: ["-dry-run=${DRY_RUN}", "-run-once=${RUN_ONCE}"]
           env:
           - name: RECONCILE_SLEEP_TIME
             value: ${RECONCILE_SLEEP_TIME}
@@ -120,6 +120,9 @@ parameters:
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'true'
+- name: RUN_ONCE
+  description: exits after one reconciliation attempt when true
+  value: 'false'
 - name: GRAPHQL_QUERY_FILE
   value: '/query.graphql'
 - name: WORKDIR


### PR DESCRIPTION
Dry run should execute on loop to function properly in stage environment. Support for a `run-once` flag should be added if deemed necessary.