### PR TITLE
include dedicated volume for git operations

### DIFF
--- a/openshift/producer.yaml
+++ b/openshift/producer.yaml
@@ -106,6 +106,12 @@ objects:
             limits:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
+          volumeMounts:
+          - name: working
+            mountPath: ${WORKDIR}  
+        volumes:
+        - name: working
+          emptyDir: {}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/git-partition-sync-producer

--- a/openshift/producer.yaml
+++ b/openshift/producer.yaml
@@ -43,7 +43,7 @@ objects:
           - name: GRAPHQL_QUERY_FILE
             value: ${GRAPHQL_QUERY_FILE}
           - name: WORKDIR
-            value: ${WORKDIR}
+            value: "${VOLUME_PATH}${WORKDIR}"
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -107,10 +107,10 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
           volumeMounts:
-          - name: working
-            mountPath: ${WORKDIR}  
+          - name: clones
+            mountPath: ${VOLUME_PATH}
         volumes:
-        - name: working
+        - name: clones
           emptyDir: {}
 parameters:
 - name: IMAGE
@@ -131,6 +131,8 @@ parameters:
   value: 'false'
 - name: GRAPHQL_QUERY_FILE
   value: '/query.graphql'
+- name: VOLUME_PATH
+  value: '/clones'
 - name: WORKDIR
   value: '/working'
 - name: MEMORY_REQUESTS


### PR DESCRIPTION
An attempt to resolve permission issue openshift security constraints. Deployment is currently erroring due to insufficient permission when performing `mkdir` commands.