### PR TITLE
clear all working files after run completes

### DIFF
--- a/pkg/encrypt.go
+++ b/pkg/encrypt.go
@@ -8,10 +8,10 @@ import (
 	"filippo.io/age"
 )
 
+const ENCRYPT_DIRECTORY = "encrypted"
+
 // utilizes x25519 to output encrypted tars
 func (u *Uploader) encryptRepoTars(toUpdate []*SyncConfig) error {
-	const ENCRYPT_DIRECTORY = "encrypted"
-
 	err := u.clean(ENCRYPT_DIRECTORY)
 	if err != nil {
 		return err

--- a/pkg/gitlab.go
+++ b/pkg/gitlab.go
@@ -25,9 +25,9 @@ func (u *Uploader) getLatestGitlabCommits() (pidToCommit, error) {
 	return latestCommits, nil
 }
 
-func (u *Uploader) cloneRepos(toUpdate []*SyncConfig) error {
-	const CLONE_DIRECTORY = "clones"
+const CLONE_DIRECTORY = "glrepos"
 
+func (u *Uploader) cloneRepos(toUpdate []*SyncConfig) error {
 	err := u.clean(CLONE_DIRECTORY)
 	if err != nil {
 		return err

--- a/pkg/tar.go
+++ b/pkg/tar.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-func (u *Uploader) tarRepos(toUpdate []*SyncConfig) error {
-	const TAR_DIRECTORY = "tars"
+const TAR_DIRECTORY = "tars"
 
+func (u *Uploader) tarRepos(toUpdate []*SyncConfig) error {
 	err := u.clean(TAR_DIRECTORY)
 	if err != nil {
 		return err

--- a/pkg/uploader.go
+++ b/pkg/uploader.go
@@ -118,6 +118,8 @@ func NewUploader(
 func (u *Uploader) Run(ctx context.Context, dryRun bool) error {
 	log.Println("Starting run...")
 
+	defer u.clear()
+
 	glCommits, err := u.getLatestGitlabCommits()
 	if err != nil {
 		return err
@@ -169,11 +171,6 @@ func (u *Uploader) Run(ctx context.Context, dryRun bool) error {
 	}
 	for _, delete := range toDelete {
 		fmt.Println(fmt.Sprintf("s3 object with key `%s` successfully deleted", *delete))
-	}
-
-	err = u.clean(u.workdir)
-	if err != nil {
-		return err
 	}
 
 	log.Println("Run successfully completed")
@@ -291,6 +288,17 @@ func (u *Uploader) clean(directory string) error {
 	cmd = exec.Command("mkdir", directory)
 	cmd.Dir = u.workdir
 	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// clear all items in working directory
+func (u *Uploader) clear() error {
+	cmd := exec.Command("rm", "-rf", ENCRYPT_DIRECTORY, TAR_DIRECTORY, CLONE_DIRECTORY)
+	cmd.Dir = u.workdir
+	err := cmd.Run()
 	if err != nil {
 		return err
 	}

--- a/pkg/uploader.go
+++ b/pkg/uploader.go
@@ -171,6 +171,11 @@ func (u *Uploader) Run(ctx context.Context, dryRun bool) error {
 		fmt.Println(fmt.Sprintf("s3 object with key `%s` successfully deleted", *delete))
 	}
 
+	err = u.clean(u.workdir)
+	if err != nil {
+		return err
+	}
+
 	log.Println("Run successfully completed")
 	return nil
 }


### PR DESCRIPTION
define and defer call to `clear` which will ensure artifacts generated during run are removed at completion of run.