### PR TITLE
include init container to populate rh internal cert

### DIFF
--- a/openshift/producer.yaml
+++ b/openshift/producer.yaml
@@ -32,6 +32,17 @@ objects:
           app: git-partition-sync-producer
       spec:
         serviceAccountName: git-partition-sync-producer
+        initContainers:
+        - name: internal-certificates
+          image: ${INTERNAL_CERTIFICATES_IMAGE}:${INTERNAL_CERTIFICATES_IMAGE_TAG}
+          imagePullPolicy: ${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            cp -r /etc/pki/. /tmp/etc-pki/
+          volumeMounts:
+          - name: internal-certificates
+            mountPath: /tmp/etc-pki/
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
@@ -109,8 +120,12 @@ objects:
           volumeMounts:
           - name: clones
             mountPath: ${VOLUME_PATH}
+          - name: internal-certificates
+            mountPath: /etc/pki/
         volumes:
         - name: clones
+          emptyDir: {}
+        - name: internal-certificates
           emptyDir: {}
 parameters:
 - name: IMAGE
@@ -121,6 +136,12 @@ parameters:
   value: latest
   displayName: git-partition-sync-producer version
   description: git-partition-sync-producer version which defaults to latest
+- name: INTERNAL_CERTIFICATES_IMAGE
+  value: quay.io/app-sre/internal-redhat-ca
+- name: INTERNAL_CERTIFICATES_IMAGE_TAG
+  value: latest
+- name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
+  value: Always
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: DRY_RUN


### PR DESCRIPTION
Address error with deployment when attempting to access internal gitlab instance