### PR TITLE
Revert "include init container to populate rh internal cert (#11)"

### DIFF
--- a/openshift/producer.yaml
+++ b/openshift/producer.yaml
@@ -28,17 +28,6 @@ objects:
           app: git-partition-sync-producer
       spec:
         serviceAccountName: git-partition-sync-producer
-        initContainers:
-        - name: internal-certificates
-          image: ${INTERNAL_CERTIFICATES_IMAGE}:${INTERNAL_CERTIFICATES_IMAGE_TAG}
-          imagePullPolicy: ${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}
-          command: ["/bin/sh", "-c"]
-          args:
-          - |
-            cp -r /etc/pki/. /tmp/etc-pki/
-          volumeMounts:
-          - name: internal-certificates
-            mountPath: /tmp/etc-pki/
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
@@ -116,12 +105,8 @@ objects:
           volumeMounts:
           - name: clones
             mountPath: ${VOLUME_PATH}
-          - name: internal-certificates
-            mountPath: /etc/pki/
         volumes:
         - name: clones
-          emptyDir: {}
-        - name: internal-certificates
           emptyDir: {}
 parameters:
 - name: IMAGE
@@ -132,12 +117,6 @@ parameters:
   value: latest
   displayName: git-partition-sync-producer version
   description: git-partition-sync-producer version which defaults to latest
-- name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
-- name: INTERNAL_CERTIFICATES_IMAGE_TAG
-  value: latest
-- name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
-  value: Always
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: DRY_RUN


### PR DESCRIPTION
This reverts commit 90229bc9cad23c6e109d35cea4ae8d1016610f19.

This is temporary revert in order to get saas deploy pipeline to pass and update image pattern. Original change can be merged again once pipeline to update image pattern is completed.