### PR TITLE
zip uploaded repo objects

### DIFF
--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -94,7 +94,7 @@ func (u *Uploader) removeOutdated(ctx context.Context, toDeleteKeys []*string) e
 
 // cocurrently uploads latest encrypted tars to target s3 bucket
 func (u *Uploader) uploadLatest(ctx context.Context, toUpdate []*SyncConfig, glCommits pidToCommit) error {
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
 
 	wg := &sync.WaitGroup{}

--- a/pkg/tar.go
+++ b/pkg/tar.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +31,10 @@ func (u *Uploader) tarRepos(toUpdate []*SyncConfig) error {
 		}
 		defer f.Close()
 
-		tw := tar.NewWriter(f)
+		gzw := gzip.NewWriter(f)
+		defer gzw.Close()
+
+		tw := tar.NewWriter(gzw)
 		defer tw.Close()
 
 		// credit: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07


### PR DESCRIPTION
gzip is being included within flow for uploading/downloading s3 objects

timeout for uploading to s3 also extended to account for large repositories